### PR TITLE
Make AlignedKeccakState repr(C)

### DIFF
--- a/src/strobe.rs
+++ b/src/strobe.rs
@@ -24,7 +24,7 @@ fn transmute_state(st: &mut AlignedKeccakState) -> &mut [u64; 25] {
 /// (since u64 words must be 8-byte aligned)
 #[derive(Clone, Zeroize)]
 #[zeroize(drop)]
-#[repr(align(8))]
+#[repr(C, align(8))]
 struct AlignedKeccakState([u8; 200]);
 
 /// A Strobe context for the 128-bit security level.


### PR DESCRIPTION
The default [repr(Rust)](https://doc.rust-lang.org/reference/type-layout.html#the-rust-representation) representation makes no guarantees about layout or alignment of its members, but we want (1) a pointer to AlignedKeccakState be the same as a pointer to its member, and (2) the member to be aligned. repr(C, align(8)) achieves that.