### PR TITLE
Replace `rand_core`'s `std` feature with `alloc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ rand_chacha = "0.3"
 default = ["std"]
 nightly = []
 debug-transcript = ["hex"]
-std = ["rand_core/std", "byteorder/std"]
+std = ["rand_core/alloc", "byteorder/std"]


### PR DESCRIPTION
# Motivation

The `std` feature from `rand_core` activates the `alloc` feature and the `getrandom` feature, which ends up including `getrandom` as a dependency.

For WebAssembly targets, it's only possible to obtain entropy if there's an external function that provides that. Because of this, `getrandom` only works if there are Javascript APIs enabled. If there aren't, it fails to build.

# Solution

The source of entropy isn't needed inside the library, therefore, the `getrandom` feature does not need to be enabled. Therefore it's enough to replace enabling the `std` feature with enabling just the `alloc` feature.

There is a use case in a documentation test, which uses `OsRng`. However, it's still not necessary to manually enable the `getrandom` feature in `dev-dependencies`, because the `curve25519-dalek` dependency's `default` feature enables `rand_core`'s `std` dependency.

# Release Notes

I believe this is a backward compatible change. I think there could be a situation where some project has a dependency on `rand_core` without its default features and on `merlin`, and unknowingly uses `getrandom`, which with this PR would fail to compile. However, the solution would be to fix the `rand_core` dependency to enable the required feature.