### PR TITLE
Bump rand_core dependency to 0.9.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,20 @@ features = ["nightly"]
 keccak = { version = "0.1.0", default-features = false }
 byteorder = { version = "1.2.4", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.9.3", default-features = false }
 hex = {version = "0.3", default-features = false, optional = true}
 
 [dev-dependencies]
 strobe-rs = "0.5"
-curve25519-dalek = { version = "4", package = "curve25519-dalek-ng" }
-rand_chacha = "0.3"
+curve25519-dalek = { version = "4.1.3", features = ["rand_core"] }
+rand_chacha = "0.9.0"
+rand = { version = "0.9.0"}
 
 [features]
 default = ["std"]
 nightly = []
 debug-transcript = ["hex"]
 std = ["rand_core/std", "byteorder/std"]
+
+[patch.crates-io]
+curve25519-dalek = { git = "https://github.com/nresare/curve25519-dalek", branch = "bump-rand-0.9" }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -233,7 +233,6 @@ impl Transcript {
 /// [`Transcript`] to an owned [`TranscriptRng`] as follows:
 /// ```
 /// # extern crate merlin;
-/// # extern crate rand_core;
 /// # use merlin::Transcript;
 /// # fn main() {
 /// # let mut transcript = Transcript::new(b"TranscriptRng doctest");
@@ -246,7 +245,7 @@ impl Transcript {
 ///     .build_rng()
 ///     .rekey_with_witness_bytes(b"witness1", witness_data)
 ///     .rekey_with_witness_bytes(b"witness2", more_witness_data)
-///     .finalize(&mut rand_core::OsRng);
+///     .finalize(&mut rand::rng());
 /// # }
 /// ```
 /// In this example, the final `rng` is a PRF of `public_data`
@@ -365,11 +364,6 @@ impl rand_core::RngCore for TranscriptRng {
         let dest_len = encode_usize_as_u32(dest.len());
         self.strobe.meta_ad(&dest_len, false);
         self.strobe.prf(dest, false);
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.fill_bytes(dest);
-        Ok(())
     }
 }
 


### PR DESCRIPTION
The reason I would like to make this change is to enable the upgrade to rand_core 0.9.x in the upstream curve25519-dalek repo which in turn would enable the upgrade to other parts of the RustCrypto set of crates.

The change is quite substantial, as can be seen here: https://github.com/nresare/curve25519-dalek/commit/22282150a326cd81f466dcfaef4f398515c85b1e so it would seem to me that making that change to the forked curve25519-dalek-ng would be quite the effort, which makes me think that it would make sense to switch back to the upstream curve25519-dalek and do a coordinated release of both packages.